### PR TITLE
ツイートに添付する画像は4枚までにする

### DIFF
--- a/cdk/lambda/crawler/crawler/infrastructures/services/tweet_news_service.py
+++ b/cdk/lambda/crawler/crawler/infrastructures/services/tweet_news_service.py
@@ -14,7 +14,7 @@ class TweetNewsService(NotifyNewsService):
     def notify(self) -> None:
         tweet_body = self.__build_tweet_body()
         image_paths = self.__download_images()
-        self.twitter_client.tweet(tweet_body, image_paths)
+        self.twitter_client.tweet(tweet_body, image_paths[:4])
 
     def __build_tweet_body(self):
         return (


### PR DESCRIPTION
Twitterの仕様上、ひとつのツイートに添付できる画像は4枚までなので、最初の4枚を添付するようにする。
