### PR TITLE
CDKスタックのIDと名称を変更

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -8,8 +8,9 @@ const app = new cdk.App();
 const stage = app.node.tryGetContext('stage');
 const config = app.node.tryGetContext('config')[stage] || {};
 
-new CdkStack(app, 'CdkStack', {
+new CdkStack(app, `tmnct-news-stack-${stage}`, {
   stage,
+  stackName: `tmnct-news-stack-${stage}`,
   ...config,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,


### PR DESCRIPTION
全部 `CdkStack` という名前でやっていたら、stagingとproductionがごっちゃになってツラミ

ついでに tmnct-news-stack という名称に変更

